### PR TITLE
Update to allow custom User classpath and also correctly implement Passport 'auth:api' guard

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,6 +3,7 @@
 use App;
 use Config;
 use Laravel\Passport\Passport;
+use LukeTowers\Passport\Classes\Authenticate;
 use System\Classes\PluginBase;
 use Illuminate\Foundation\AliasLoader;
 
@@ -11,6 +12,10 @@ use Illuminate\Foundation\AliasLoader;
  */
 class Plugin extends PluginBase
 {
+    public $middlewareAliases = [
+        'auth' => Authenticate::class
+    ];
+
     /**
      * Returns information about this plugin.
      *
@@ -27,11 +32,29 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function registerSettings()
+    {
+        return [
+            'settings' => [
+                'label'       => 'Passport Settings',
+                'description' => 'Manage passport based settings.',
+                'category'    => 'Passport',
+                'icon'        => 'icon-cog',
+                'class'       => 'LukeTowers\Passport\Models\Settings',
+                'order'       => 500,
+                'keywords'    => 'user auth passport'
+            ]
+        ];
+    }
+
     /**
      * Runs right before the request route
      */
     public function boot()
     {
+        // Boot middleware aliases
+        $this->aliasMiddleware();
+
         // Disable the Laravel migrations from Passport, handled via plugin updates
         Passport::ignoreMigrations();
 
@@ -79,6 +102,20 @@ class Plugin extends PluginBase
                     $aliasLoader->alias($alias, $path);
                 }
             }
+        }
+    }
+
+    /**
+     * Registers provided middleware aliases with the router
+     */
+    protected function aliasMiddleware()
+    {
+        $router = $this->app['router'];
+
+        $method = method_exists($router, 'aliasMiddleware') ? 'aliasMiddleware' : 'middleware';
+
+        foreach ($this->middlewareAliases as $alias => $middleware) {
+            $router->$method($alias, $middleware);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ WORK-IN-PROGRESS Laravel Passport integration for OctoberCMS
 
 # Installation
 Add the plugin to your application and then run `php artisan october:up` to run the plugin's migrations.
-Following https://laravel.com/docs/5.5/passport#installation would have you run `php artisan passport:install`.
-Read https://laravel.com/docs/5.5/passport for more information on using Passport.
+Following https://laravel.com/docs/6.x/passport#installation would have you run `php artisan passport:install`.
+Read https://laravel.com/docs/6.x/passport for more information on using Passport.
 
 **NOTE:**
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 WORK-IN-PROGRESS Laravel Passport integration for OctoberCMS
 
 # Installation
-Add the plugin to your application and then run `php artisan october:up` to run the plugin's migrations. Following https://laravel.com/docs/5.5/passport#installation would have you run `php artisan passport:install`. Read https://laravel.com/docs/5.5/passport for more information on using Passport.
+Add the plugin to your application and then run `php artisan october:up` to run the plugin's migrations.
+Following https://laravel.com/docs/5.5/passport#installation would have you run `php artisan passport:install`.
+Read https://laravel.com/docs/5.5/passport for more information on using Passport.
 
-**NOTE:** The default backend user model is extended to work with Passport via the `LukeTowers\Passport\Models\BackendUser` model, use that instead of `Backend\Models\User` when working with Passport.
+**NOTE:**
+
+The default backend user model is extended to work with Passport via the `LukeTowers\Passport\Models\BackendUser` model, use that instead of `Backend\Models\User` when working with Passport.
+
+To use a different use model simply update the class path via settings.  Noting that the given class must use `HasApiTokens` as per Passport documentation.

--- a/classes/Authenticate.php
+++ b/classes/Authenticate.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace LukeTowers\Passport\Classes;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+
+/**
+ * Class Authenticate
+ * This class is heavily based off Illuminate\Auth\Middleware\Authenticate however replaces
+ * error causing Factory implementations with the 'Auth' reference in Octobers IOC
+ * @package LukeTowers\Passport\Classes
+ */
+class Authenticate
+{
+    /**
+     * The authentication factory instance.
+     */
+    protected $auth;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->auth = app()['auth'];
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param Closure $next
+     * @param  string[]  ...$guards
+     * @return mixed
+     *
+     */
+    public function handle($request, Closure $next, ...$guards)
+    {
+        try {
+            $this->authenticate($guards);
+        } catch (AuthenticationException $e) {
+            return response()->json(['error' => 'Unauthenticated!'], 401);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the user is logged in to any of the given guards.
+     *
+     * @param  array  $guards
+     * @return void
+     *
+     * @throws AuthenticationException
+     */
+    protected function authenticate(array $guards)
+    {
+        if (empty($guards)) {
+            return $this->auth->authenticate();
+        }
+
+        foreach ($guards as $guard) {
+            if ($this->auth->guard($guard)->check()) {
+                return $this->auth->shouldUse($guard);
+            }
+        }
+
+        throw new AuthenticationException('Unauthenticated.', $guards);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "composer/installers": "~1.0",
-        "laravel/passport": "~4.0"
+        "laravel/passport": "~8.5",
+        "lcobucci/jwt": "3.3.3"
     }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -74,7 +74,7 @@
                 'providers' => [
                     'users' => [
                         'driver' => 'eloquent',
-                        'model' => \LukeTowers\Passport\Models\BackendUser::class,
+                        'model' => \LukeTowers\Passport\Models\Settings::get('user_class', 'LukeTowers\Passport\Models\BackendUser'),
                     ],
 
                     // 'users' => [

--- a/models/BackendUser.php
+++ b/models/BackendUser.php
@@ -2,38 +2,12 @@
 
 use Backend\Models\User as BackendUserModel;
 
-// Authenticates the user for logging in and manages the remember token
-// Initial compatibility with Illumninate.Auth
-use Illuminate\Auth\Authenticatable;
-use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
-
 // Initial compatibility with Laravel.Passport
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Notifications\Notifiable;
 
-// Manages the user's access to the application using Laravel's concept
-// of 'Gates' & 'Policies'. See https://laravel.com/docs/5.5/authorization
-// A parallel could in theory be constructed to use October's permission
-// system
-// use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
-// use Illuminate\Foundation\Auth\Access\Authorizable;
-
-// Triggers sending a password reset notification for the user
-// use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
-// use Illuminate\Auth\Passwords\CanResetPassword;
-
-class BackendUser extends BackendUserModel implements AuthenticatableContract
+class BackendUser extends BackendUserModel
 {
-    use Authenticatable,
-        HasApiTokens,
+    use HasApiTokens,
         Notifiable;
-
-    /**
-     * The column name of the "remember me" token.
-     *
-     * @var string
-     */
-    protected $rememberTokenName = 'persist_code';
-
-
 }

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LukeTowers\Passport\Models;
+
+use Model;
+
+class Settings extends Model
+{
+    public $implement = ['System.Behaviors.SettingsModel'];
+
+    // A unique code
+    public $settingsCode = 'luketowers_passport_settings';
+
+    // Reference to field configuration
+    public $settingsFields = 'fields.yaml';
+}

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,0 +1,7 @@
+fields:
+    user_class:
+        label: "User Model Class"
+        span: auto
+        required: 1
+        type: text
+        comment: "i.e. Backend\\Models\\User. Default: LukeTowers\\Passport\\Models\\BackendUser"


### PR DESCRIPTION
As the title suggests and as mentioned in #3 
Note that although this is working for my case, given no tests exist it may fail on edge cases so the main NOTE in README.md has been left.